### PR TITLE
🐛 마이페이지 개인 정보 수정 기능 진행간 Mapper, DTO 수정

### DIFF
--- a/server/src/main/java/com/seb028/guenlog/member/controller/MyPageController.java
+++ b/server/src/main/java/com/seb028/guenlog/member/controller/MyPageController.java
@@ -71,12 +71,12 @@ public class MyPageController {
         myPageInfo.getMember().setId(memberId);
 
         // MyPageService에서 MyPageInfo 객체 전달하여 개인정보 수정
-        MyPageInfo updateMyPageInfo =
+        MyPageInfo updatedMyPageInfo =
                 myPageService.updateMyPageInfo(myPageInfo);
 
         // 수정 완료를 MyPageInfoResponseDTO와 함께 HttpStatus OK로 리턴
         return new ResponseEntity<>(
-                new SingleResponseDto<>(myPageInfoMapper.myPageInfoToMyPageInfoResponseDto(myPageInfo)),
+                new SingleResponseDto<>(myPageInfoMapper.myPageInfoToMyPageInfoResponseDto(updatedMyPageInfo)),
                 HttpStatus.OK);
     }
 

--- a/server/src/main/java/com/seb028/guenlog/member/dto/MyPageInfoDto.java
+++ b/server/src/main/java/com/seb028/guenlog/member/dto/MyPageInfoDto.java
@@ -12,7 +12,6 @@ public class MyPageInfoDto {
     @Getter
     @Builder
     public static class Patch {
-        @NotBlank(message = "닉네임은 필수 입력 항목입니다")
         @Pattern(regexp = "^([a-zA-Z가-힣]){1,8}$",
                 message = "닉네임은 한글 최대 8글자까지 입력 가능합니다.")
         private String nickname;

--- a/server/src/main/java/com/seb028/guenlog/member/mapper/MyPageInfoMapper.java
+++ b/server/src/main/java/com/seb028/guenlog/member/mapper/MyPageInfoMapper.java
@@ -17,6 +17,7 @@ public interface MyPageInfoMapper {
 
         return MyPageInfoDto.Response.builder()
                 .nickname(member.getNickname())
+                .email(member.getEmail())
                 .gender(member.getGender())
                 .height(member.getHeight())
                 .weight(memberWeight.getWeight())
@@ -27,7 +28,8 @@ public interface MyPageInfoMapper {
     default MyPageInfo myPageInfoPatchDtoToMyPageInfo(MyPageInfoDto.Patch myPageInfoPatchDto) {
         Member member = new Member();
         member.setNickname(myPageInfoPatchDto.getNickname());
-        member.setAge(LocalDate.parse(myPageInfoPatchDto.getAge()));
+        if (myPageInfoPatchDto.getAge() != null)
+            member.setAge(LocalDate.parse(myPageInfoPatchDto.getAge()));
         member.setGender(myPageInfoPatchDto.getGender());
         member.setHeight(myPageInfoPatchDto.getHeight());
 


### PR DESCRIPTION
- MyPageInfoMapper 클래스에서 ResponseDto로 변환하는 메서드에 email값 매핑 추가
- MyPageInfoMapper 클래스에서 PatchDto를 변환시 age가 null이 아닐 때의 경우 추가
- MyPageInfoPatchDto 클래스에서 nickname이 not blacnk에 대한 유효성 검사 부분 삭제