### PR TITLE
✅ Spring Rest Docs API 문서 생성 위한 gradle 설정 및 테스트용 클래스 추가 

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -53,6 +53,8 @@ dependencies {
 	// spring restdocs asciidoctor 의존 라이브러리 추가
 	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
+	implementation 'com.google.code.gson:gson'	// json 변환 라이브러리
+
 }
 
 tasks.named('test') {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.5'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+	id "org.asciidoctor.jvm.convert" version "3.3.2"		// AsciiDoc 문서 생성하는 AsciiDoctor 플러그인 추가
 }
 
 group = 'com.seb028'
@@ -12,6 +13,14 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
+}
+
+ext {
+	set('snippetsDir', file("build/generated-snippets"))		// API 문서 스니핏 생성 경로 지정
+}
+
+configurations {		// AsciiDoctor에서 사용되는 의존 그룹 지정
+	asciidoctorExtensions
 }
 
 repositories {
@@ -39,8 +48,42 @@ dependencies {
 	//json 형식을 넣기위해서 추가
 	implementation 'com.vladmihalcea:hibernate-types-52:2.16.2'
 
+	// spring restdocs 의존 라이브러리 추가
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	// spring restdocs asciidoctor 의존 라이브러리 추가
+	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+
 }
 
 tasks.named('test') {
+	// test Task 실행시 API 문서 생성 스니핏 디렉토리 경로 설정
+	outputs.dir snippetsDir
 	useJUnitPlatform()
+}
+
+// asciidoctor task 실행시 assciidoctor 기능 사용
+tasks.named('asciidoctor') {
+	configurations "asciidoctorExtensions"
+	inputs.dir snippetsDir
+	dependsOn test
+}
+
+// build task 실행 전 index.html 파일 copy 실행 API 문서를 파일 형태로 외부에 제공
+task copyDocument(type: Copy) {
+	dependsOn asciidoctor
+	from file("${asciidoctor.outputDir}")
+	into file("src/main/resources/static/docs")
+}
+
+// build task 실행 전 copyDocument task 먼저 수행
+build {
+	dependsOn copyDocument
+}
+
+// bootJar task 설정
+bootJar {
+	dependsOn copyDocument    // bootJar task 실행 전 copyDocument task 실행
+	from ("${asciidoctor.outputDir}") {  // index.html 파일을 jar 파일 안에 추가
+		into'static/docs'
+	}
 }

--- a/server/src/test/java/com/seb028/restdocs/exercise/ExerciseProgressControllerRestDocsTest.java
+++ b/server/src/test/java/com/seb028/restdocs/exercise/ExerciseProgressControllerRestDocsTest.java
@@ -1,0 +1,45 @@
+package com.seb028.restdocs.exercise;
+
+import com.google.gson.Gson;
+import com.seb028.guenlog.exercise.dto.ExercisePlanRequestDto;
+import com.seb028.guenlog.exercise.dto.ExerciseProgressResponseDto;
+import com.seb028.guenlog.exercise.mapper.ExerciseProgressMapper;
+import com.seb028.guenlog.exercise.service.ExerciseProgressService;
+import com.seb028.guenlog.exercise.util.ExerciseProgress;
+import com.seb028.guenlog.member.service.MemberService;
+import com.seb028.guenlog.response.SingleResponseDto;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+
+@WebMvcTest
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureRestDocs
+public class ExerciseProgressControllerRestDocsTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ExerciseProgressService exerciseProgressService;
+
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private ExerciseProgressMapper mapper;
+
+    @Autowired
+    private Gson gson;
+    
+}


### PR DESCRIPTION
- Spring Rest Docs API 문서 생성하기 위한 build.gradle 설정
- 테스트용 패키지 경로 추가 
- 운동 진행 ExerciseProgressController 테스트용 클래스 추가