### PR TITLE
✅ 운동 진행 조회 - Controller 테스트, Spring Rest Docs을 이용한 API 문서화 

### DIFF
--- a/server/src/docs/asciidoc/index.adoc
+++ b/server/src/docs/asciidoc/index.adoc
@@ -1,0 +1,34 @@
+= GuenLog
+:sectnums:
+:toc: left
+:toclevels: 4
+:toc-title: Table of Contents
+:source-highlighter: prettify
+
+Kim Young Min
+
+v0.0.1 2022.11.30
+
+***
+== ExerciseProgressController
+=== 운동 진행  조회
+.curl-request
+include::{snippets}/get-exerciseProgress/curl-request.adoc[]
+
+.http-request
+include::{snippets}/get-exerciseProgress/curl-request.adoc[]
+
+.request-parameters
+include::{snippets}/get-exerciseProgress/request-parameters.adoc[]
+
+.request-header
+include::{snippets}/get-exerciseProgress/request-headers.adoc[]
+
+.http-response
+include::{snippets}/get-exerciseProgress/http-response.adoc[]
+
+.response-body
+include::{snippets}/get-exerciseProgress/response-body.adoc[]
+
+.response-fields
+include::{snippets}/get-exerciseProgress/response-fields.adoc[]

--- a/server/src/test/java/com/seb028/guenlog/restdocs/exercise/ExerciseProgressControllerRestDocsTest.java
+++ b/server/src/test/java/com/seb028/guenlog/restdocs/exercise/ExerciseProgressControllerRestDocsTest.java
@@ -1,7 +1,6 @@
 package com.seb028.guenlog.restdocs.exercise;
 
 import com.google.gson.Gson;
-import com.seb028.guenlog.GuenLogApplication;
 import com.seb028.guenlog.config.SecurityConfig;
 import com.seb028.guenlog.config.auth.JwtTokenizer;
 import com.seb028.guenlog.config.auth.jwt.filter.JwtAuthenticationFilter;
@@ -15,13 +14,11 @@ import com.seb028.guenlog.exercise.mapper.ExerciseProgressMapper;
 import com.seb028.guenlog.exercise.service.ExerciseProgressService;
 import com.seb028.guenlog.exercise.util.ExerciseProgress;
 import com.seb028.guenlog.member.service.MemberService;
-import com.seb028.guenlog.response.SingleResponseDto;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
@@ -45,9 +42,9 @@ import java.util.List;
 import static com.seb028.util.ApiDocumentUtils.getRequestPreprocessor;
 import static com.seb028.util.ApiDocumentUtils.getResponsePreProcessor;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -82,90 +79,106 @@ public class ExerciseProgressControllerRestDocsTest {
     @Test
     @WithMockUser()
     public void getExerciseProgressTest() throws Exception {
-        // given
-        // 테스트 데이터
+        // <<< given >>>
+        // 한 운동 세트에 대한 무게, 횟수, 휴식 시간, 세트 완료 여부 응답용 객체
         ExercisePlanRequestDto.EachRecords eachRecord = new ExercisePlanRequestDto.EachRecords();
         eachRecord.setWeight(50);
         eachRecord.setCount(12);
         eachRecord.setTimer(60);
         eachRecord.setEachCompleted(false);
 
+        // 한 운동에 대한 각 세트 리스트 응답용 객체
         List<ExercisePlanRequestDto.EachRecords> eachRecords = new ArrayList<ExercisePlanRequestDto.EachRecords>();
         eachRecords.add(eachRecord);
 
+        // 오늘 하루 운동 응답용 객체
         ExerciseProgressResponseDto.TodayExerciseDto todayExerciseDto = ExerciseProgressResponseDto.TodayExerciseDto.builder()
-                .exerciseName("스쿼트 ")
-                .exerciseId(1L)
-                .imageUrl("s3.somewhere")
-                .isCompleted(false)
-                .eachRecords(eachRecords)
+                .exerciseName("스쿼트 ")      // 운동 이름
+                .exerciseId(1L)                  // 운동 ID
+                .imageUrl("s3.somewhere")         // 운동이미지 URL
+                .isCompleted(false)            // 운동 완료 여부
+                .eachRecords(eachRecords)                   // 각 세트 리스트
                 .build();
 
+        // 오늘 하루 운동 리스트 응답용 객체
         List<ExerciseProgressResponseDto.TodayExerciseDto> exercises = new ArrayList<ExerciseProgressResponseDto.TodayExerciseDto>();
         exercises.add(todayExerciseDto);
 
+        // 운동 진행 조회할 때 응답 DTO 객체
         ExerciseProgressResponseDto responseDto = ExerciseProgressResponseDto.builder()
-                .todayId(1L)
-                .totalTime(600)
-                .exercises(exercises)
+                .todayId(1L)         // 오늘 하루 운동의 ID
+                .totalTime(600)     // 총 운동 시간
+                .exercises(exercises)         // 운동들 목록 리스트
                 .build();
 
+        // 오늘 하루 운동에 대한 객체
         Today today = Today.builder()
-                .id(1L)
-                .totalTime(600)
+                .id(1L)                     // ID
+                .totalTime(600)     // 총 운동 시간
                 .build();
 
+        // 오늘 하루 운동 기록에 대한 객체
         Record record = Record.builder()
-                .today(today)
-                .isCompleted(false)
-                .eachRecords(eachRecords)
+                .today(today)                   // 오늘 하루 운동에 대한 객체
+                .isCompleted(false)     // 운동 완료 여부
+                .eachRecords(eachRecords)           // 각 세트 리스트
                 .build();
 
+        // 오늘 하루 운동 기록 리스트에 대한 객체
         List<Record> records = new ArrayList<Record>();
         records.add(record);
 
+        // 운동 진행에 대한 객체
         ExerciseProgress exerciseProgress = ExerciseProgress.builder()
-                .today(today)
-                .records(records)
+                .today(today)           // 오늘 하루 객체
+                .records(records)       // 운동 기록 리스트 객체
                 .build();
 
-        long memberId = 1L;
+        long memberId = 1L;     // 사용자 ID
 
-        String date = "2022-11-29";
-        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        String date = "2022-11-29";         // 운동 진행할 날짜
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();    // 쿼리 파라미터
         queryParams.add("date", date);
 
+        // -- Stubbing --
+        // memberService로 사용자 ID찾는 메서드 Stubbing
         given(memberService.findMemberId(
                 Mockito.any(HttpServletRequest.class)))
                 .willReturn(memberId);
 
+        // 오늘 하루 운동진행에 대한 ExercisesProgress 객체 조회 메서드 Stubbing
         given(exerciseProgressService.findTodayExerciseProgress(
                 Mockito.any(LocalDate.class), Mockito.anyLong()))
                 .willReturn(exerciseProgress);
 
+        // ExerciseProgress 객체를 응답용DTO로 변환하는 매퍼 Stubbing
         given(mapper.exerciseProgressToExerciseProgressResponseDto(
                 Mockito.any(ExerciseProgress.class)))
                 .willReturn(responseDto);
 
-        // when
+        // <<< when >>>
         ResultActions actions =
                 mockMvc.perform(
-                RestDocumentationRequestBuilders.get("/exercises/progress")
-                                    .params(queryParams)
+                RestDocumentationRequestBuilders.get("/exercises/progress")     // GET 요청시
+                        .header("Authorization", "Bearer {AccessToken}")                    // 헤더에 토큰 추가
+                                    .params(queryParams)                                                   // 쿼리 파라미터 (운동 진행 날짜)
                                     .accept(MediaType.APPLICATION_JSON));
 
-        // then
+        // <<< then >>>
         MvcResult result =  actions
                 .andExpect(status().isOk())
                 .andDo(
-                document(
+                document(       // rest doc 생성
                     "get-exerciseProgress",
                                 getRequestPreprocessor(),
                                 getResponsePreProcessor(),
-                    requestParameters(
+                    requestParameters(      // 쿼리 파라미터
                                         parameterWithName("date").description("운동 진행 날짜 (오늘)")
                                 ),
-                                responseFields(
+                                requestHeaders(         // 헤더
+                                        headerWithName("Authorization").description("Bearer + {로그인 요청 Access 토큰}")
+                                ),
+                                responseFields(         // 응답 필드
                                         Arrays.asList(
                                                 fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),
                                                 fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),

--- a/server/src/test/java/com/seb028/util/ApiDocumentUtils.java
+++ b/server/src/test/java/com/seb028/util/ApiDocumentUtils.java
@@ -1,0 +1,20 @@
+package com.seb028.util;
+
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
+// 문서 스니핏 생성 전 request, response에 해당하는 문서 영역 전처리하는 클래스
+public interface ApiDocumentUtils {
+    // 문서에 표시되는 JSON 포맷의 request body를 예쁘게 표현
+    static OperationRequestPreprocessor getRequestPreprocessor() {
+        return preprocessRequest(prettyPrint());
+    }
+
+    // 문서에 표시되는 JSON 포맷의 response body를 예쁘게 표현
+    static OperationResponsePreprocessor getResponsePreProcessor() {
+        return preprocessResponse(prettyPrint());
+    }
+
+}


### PR DESCRIPTION
- ExerciseProgressControllerRestDocsTest 클래스에 운동 진행 조회 테스트 메서드 구현
- responseBody, request body 를 잘 표현하게 해줄 API 문서화 유틸 ApiDocumentUtils 인터페이스 구현
- ExerciseProgressControllerRestDocsTest 클래스에 운동 진행 조회 테스트 코드에 HTTP 요청시에 대한 헤더 추가
- Rest doc API 문서 index.adoc 생성
- 운동 진행 조회 API index.adoc에 내용 추가
- 불필요한 import 문 제거
- 주석 추가